### PR TITLE
[kilted] Update deprecated call to ament_target_dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ include_directories(
 
 add_executable(example_node example/example_node.cpp)
 set_property(TARGET example_node PROPERTY CXX_STANDARD 17)
-ament_target_dependencies(example_node rclcpp)
+target_link_libraries(example_node PUBLIC rclcpp)
 
 install(TARGETS example_node
   DESTINATION lib/${PROJECT_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ include_directories(
 
 add_executable(example_node example/example_node.cpp)
 set_property(TARGET example_node PROPERTY CXX_STANDARD 17)
-target_link_libraries(example_node PUBLIC rclcpp)
+target_link_libraries(example_node PUBLIC rclcpp::rclcpp)
 
 install(TARGETS example_node
   DESTINATION lib/${PROJECT_NAME}


### PR DESCRIPTION
As of the ROS 2 Kilted release [`ament_target_dependencies` is deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)

This PR updates the syntax. Caution should be used to ensure that the target branch is not used for other ROS 2 distros.

Note: This PR was generated by a bot script, but using the simple pattern matching of the [`ros_glint`](https://github.com/MetroRobots/ros_glint) library. No LLMs were used.
